### PR TITLE
fix && and || expression chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2022-07-29
+### Fixed
+- && and || expression chaining.
+
 ## [0.3.1] - 2022-07-19
 ### Fixed
 - Fixed number parsing for exponential numbers eg. 1e10.
@@ -35,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial conversion from https://github.com/rust-playground/ksql.
 
-[Unreleased]: https://github.com/go-playground/ksql/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/go-playground/ksql/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/go-playground/ksql/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/go-playground/ksql/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/go-playground/ksql/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/go-playground/ksql/compare/v0.1.1...v0.2.0

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -93,7 +93,7 @@ func BenchmarkParsingCoerceDateTimeSelectorConstant(b *testing.B) {
 }
 
 func BenchmarkExecutionNumPlusNum(b *testing.B) {
-	benchExecution(b, "1 + 1", ``)
+	benchExecution(b, "1 + 1 + 1 + 1 + 1", ``)
 }
 
 func BenchmarkExecutionIdentNum(b *testing.B) {

--- a/parser.go
+++ b/parser.go
@@ -117,7 +117,7 @@ func (p *parser) parseValue(token Token) (Expression, error) {
 		expression, err := p.parseExpression()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, errors.New("expression after open parenthesis '(' ends unexpectedly.")
+				return nil, errors.New("expression after open parenthesis '(' ends unexpectedly")
 			}
 			return nil, err
 		}
@@ -347,12 +347,11 @@ func (p *parser) parseOperation(token Token, current Expression) (Expression, er
 		}, nil
 
 	case Or:
-		nextToken, err := p.nextOperatorToken(token)
+		right, err := p.parseExpression()
 		if err != nil {
-			return nil, err
-		}
-		right, err := p.parseValue(nextToken)
-		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil, errors.New("expression after or '||' ends unexpectedly")
+			}
 			return nil, err
 		}
 		return or{
@@ -361,12 +360,11 @@ func (p *parser) parseOperation(token Token, current Expression) (Expression, er
 		}, nil
 
 	case And:
-		nextToken, err := p.nextOperatorToken(token)
+		right, err := p.parseExpression()
 		if err != nil {
-			return nil, err
-		}
-		right, err := p.parseValue(nextToken)
-		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil, errors.New("expression after or '&&' ends unexpectedly")
+			}
 			return nil, err
 		}
 		return and{

--- a/parser_test.go
+++ b/parser_test.go
@@ -518,6 +518,42 @@ func TestParser(t *testing.T) {
 			src:      ``,
 			expected: true,
 		},
+		{
+			name:     "random expression 1",
+			exp:      `.NumberOfEmployees > "200" && .AnnualRevenue == "2000000"`,
+			src:      `{"AnnualRevenue":"2000000","NumberOfEmployees":"201","FirstName":"scott"}`,
+			expected: true,
+		},
+		{
+			name:     "random expression 2",
+			exp:      `.AnnualRevenue >= "5000000" || (.NumberOfEmployees > "200" && .AnnualRevenue == "2000000")`,
+			src:      `{"AnnualRevenue":"2000000","NumberOfEmployees":"201","FirstName":"scott"}`,
+			expected: true,
+		},
+		{
+			name:     "random expression 3",
+			exp:      `.AnnualRevenue >= "5000000" || (true && .AnnualRevenue == "2000000")`,
+			src:      `{"AnnualRevenue":"2000000","NumberOfEmployees":"201","FirstName":"scott"}`,
+			expected: true,
+		},
+		{
+			name:     "random expression 4",
+			exp:      `.AnnualRevenue >= "5000000" || (.NumberOfEmployees > "200" && true)`,
+			src:      `{"AnnualRevenue":"2000000","NumberOfEmployees":"201","FirstName":"scott"}`,
+			expected: true,
+		},
+		{
+			name:     "random expression 5",
+			exp:      `true || (.NumberOfEmployees > "200" && .AnnualRevenue == "2000000")`,
+			src:      `{"AnnualRevenue":"2000000","NumberOfEmployees":"201","FirstName":"scott"}`,
+			expected: true,
+		},
+		{
+			name:     "random expression 6",
+			exp:      `false || (.NumberOfEmployees > "200" && .AnnualRevenue == "2000000")`,
+			src:      `{"AnnualRevenue":"2000000","NumberOfEmployees":"201","FirstName":"scott"}`,
+			expected: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Fix multiple `&&` and `||` expression chaining.